### PR TITLE
Fix affichage initial des notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -705,6 +705,9 @@
     // Recherche en temps réel
     inputRecherche.addEventListener("input", renderNotes);
 
+    // Afficher toutes les notes dès le chargement
+    renderNotes();
+
     // Gestion du modal de suppression
     confirmDeleteBtn.onclick = () => {
       if (idNoteToDelete) {


### PR DESCRIPTION
## Summary
- affiche toutes les notes dès le chargement de la page pour que l'utilisateur n'ait pas à cliquer dans la barre de recherche

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d650fadf0833395a6fabe62982454