### PR TITLE
Fix input container positioning and add note list padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,17 +51,19 @@
       position: fixed;
       bottom: 0;
       left: 0;
-      width: 100%;
-      box-sizing: border-box;
-      padding: 0.75rem;
-      display: flex;
-      background-color: #fafafa;
+      right: 0;
+      z-index: 10;
+      background-color: #fff;
+      padding: 10px;
       border-top: 1px solid #ccc;
+      display: flex;
+      gap: 10px;
+      box-sizing: border-box;
     }
     #nouveau-note textarea {
       flex: 1;
-      width: 100%;
-      resize: vertical;
+      height: 60px;
+      resize: none;
       padding: 0.5rem;
       font-size: 1rem;
       border: 1px solid #ccc;
@@ -112,6 +114,7 @@
       border: 1px solid #ddd;
       border-radius: 4px;
       padding: 0.5rem;
+      padding-bottom: 100px;
     }
     .note {
       padding: 0.5rem;


### PR DESCRIPTION
## Summary
- keep the input container fixed at the bottom with `position: fixed`
- prevent the input from moving when the mobile keyboard opens
- add bottom padding to the notes container so notes don't overlap the input area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d848c7e1483339b7fa183f73ed80f