### PR TITLE
Improve note layout and input spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
       font-family: Arial, sans-serif;
       margin: 0;
       padding: 0;
-      padding-bottom: 5rem;
       background-color: #f7f7f7;
       display: flex;
       flex-direction: column;
@@ -52,20 +51,21 @@
       bottom: 0;
       left: 0;
       right: 0;
-      z-index: 10;
-      background-color: #fff;
-      padding: 10px;
+      background: #fff;
+      padding: 8px;
       border-top: 1px solid #ccc;
       display: flex;
+      align-items: center;
       gap: 10px;
       box-sizing: border-box;
+      z-index: 999;
     }
     #nouveau-note textarea {
       flex: 1;
-      height: 60px;
+      height: 50px;
       resize: none;
       padding: 0.5rem;
-      font-size: 1rem;
+      font-size: 0.875rem;
       border: 1px solid #ccc;
       border-radius: 4px 0 0 4px;
     }
@@ -114,20 +114,20 @@
       border: 1px solid #ddd;
       border-radius: 4px;
       padding: 0.5rem;
-      padding-bottom: 100px;
+      padding-bottom: 80px;
     }
     .note {
-      padding: 0.5rem;
+      padding: 10px;
       position: relative;
       white-space: pre-wrap;    /* conserve sauts de ligne */
       word-break: break-word;   /* retour à la ligne pour mots longs */
       cursor: default;
-      border-bottom: 2px solid #27ae60; /* séparation verte */
-      margin-bottom: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      margin-bottom: 8px;
       padding-bottom: 1.5rem;   /* espace pour la date et l’auteur */
     }
     .note:last-child {
-      border-bottom: none;
       margin-bottom: 0;
       padding-bottom: 0.5rem;
     }


### PR DESCRIPTION
## Summary
- shrink whitespace around notes
- reduce input textarea height
- adjust layout spacing for note list and fixed input bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d92267d2c833396d41654c479da5b