### PR TITLE
Fix notes overlap with fixed input

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
     .notes-section {
       width: 100%;
       box-sizing: border-box;
+      padding-bottom: 60px; /* espace pour le champ de saisie fixe */
     }
 
     /* Champ d\'état de recherche désactivé */


### PR DESCRIPTION
## Summary
- add bottom padding to the notes results section to prevent overlap with the fixed textarea

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d9b5e390c83339d60e4dbf66d7b28