### PR TITLE
Fix bottom input overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
     .notes-section {
       width: 100%;
       box-sizing: border-box;
-      padding-bottom: 70px; /* espace pour le champ de saisie fixe */
+      padding-bottom: 80px; /* espace pour le champ de saisie fixe */
     }
 
     /* Champ d\'état de recherche désactivé */
@@ -115,7 +115,7 @@
       border: 1px solid #ddd;
       border-radius: 4px;
       padding: 0.5rem;
-      padding-bottom: 70px;
+      padding-bottom: 80px;
     }
     .note {
       padding: 10px;


### PR DESCRIPTION
## Summary
- add extra padding to notes container so fixed input doesn't overlap

## Testing
- `grep -n "padding-bottom: 80px" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_684da222d6d48333afb681a5572ab997