### PR TITLE
Fix emoji spacing in note input

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     #noteInput {
       flex: 1;
       height: 40px;              /* hauteur réduite */
-      padding: 8px 8px 8px 35px; /* espace pour l'emoji */
+      padding: 8px 8px 8px 2.5em; /* espace pour l'emoji */
       font-size: 14px;
       border: 1px solid #ccc;
       border-radius: 6px;


### PR DESCRIPTION
## Summary
- add left padding for text entry field so text doesn't overlap with emoji button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dbe30c3dc8333bb47cbf502c1c794