### PR TITLE
Add character limit with dynamic counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,12 +69,20 @@
     #noteInput {
       flex: 1;
       height: 40px;              /* hauteur réduite */
-      padding: 8px 8px 8px 3.2em; /* laisse plus d'espace pour l'emoji */
+      padding: 8px 40px 8px 3.2em; /* laisse plus d'espace pour l'emoji et le compteur */
       font-size: 14px;
       border: 1px solid #ccc;
       border-radius: 6px;
       resize: none;
       box-sizing: border-box;
+    }
+    .char-counter {
+      position: absolute;
+      bottom: 6px;
+      right: 10px;
+      font-size: 10px;
+      color: #888;
+      pointer-events: none;
     }
     #emojiButton {
       position: absolute;
@@ -508,7 +516,8 @@
     <!-- Zone de saisie pour une nouvelle note -->
     <div id="inputContainer">
       <button id="emojiButton">🥰</button>
-      <textarea id="noteInput" rows="2" placeholder="Écrivez ici…"></textarea>
+      <textarea id="noteInput" rows="2" placeholder="Écrivez ici…" maxlength="600"></textarea>
+      <div class="char-counter">0 / 600</div>
       <button id="addButton">Ajouter</button>
       <div id="emojiPicker" class="emoji-picker">
         <button data-emoji="🥰">🥰</button>
@@ -574,7 +583,7 @@
   <!-- Modal d'édition de note -->
   <div id="modalNoteOverlay">
     <div id="modalNoteContent">
-      <textarea id="noteTextarea" rows="5"></textarea>
+      <textarea id="noteTextarea" rows="5" maxlength="600"></textarea>
       <div class="modal-buttons">
         <button class="modal-btn save" id="saveNote">Sauvegarder</button>
         <button class="modal-btn cancel" id="cancelNote">Annuler</button>
@@ -635,6 +644,8 @@
 
     // Éléments DOM
     const textarea         = document.getElementById("noteInput");
+    const charCounter      = document.querySelector(".char-counter");
+    charCounter.textContent = `${textarea.value.length} / 600`;
     const btnAjouter       = document.getElementById("addButton");
     const emojiBtn         = document.getElementById("emojiButton");
     const emojiPicker      = document.getElementById("emojiPicker");
@@ -660,12 +671,17 @@
       textarea.selectionStart = textarea.selectionEnd = start + emoji.length;
       textarea.focus();
       emojiPicker.style.display = "none";
+      charCounter.textContent = `${textarea.value.length} / 600`;
     });
 
     document.addEventListener("click", (e) => {
       if (!emojiPicker.contains(e.target) && e.target !== emojiBtn) {
         emojiPicker.style.display = "none";
       }
+    });
+
+    textarea.addEventListener("input", () => {
+      charCounter.textContent = `${textarea.value.length} / 600`;
     });
 
     // Sur mobile, remonter la zone de texte au-dessus du clavier
@@ -980,6 +996,7 @@
       ajouterNoteDansFirestore(texte);
       textarea.value = "";
       textarea.focus();
+      charCounter.textContent = "0 / 600";
       scrollToBottom();
     });
 


### PR DESCRIPTION
## Summary
- enforce 600 character limit on the note input field
- show a character counter inside the textarea
- update counter on user input and emoji insertion
- reset counter after submitting a note
- limit editing textarea to 600 characters

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684dc9000a848333a8606beae318f5ce