### PR TITLE
Fix modal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
       min-height: 100vh;
     }
 
+    body.modal-open {
+      overflow: hidden;
+    }
     body.modal-open #inputContainer {
       position: static;
     }
@@ -917,7 +920,13 @@
       modalNoteOverlay.style.display = "flex";
       body.classList.add("modal-open");
       setTimeout(() => {
-        noteTextarea.focus();
+        if (noteTextarea.focus) {
+          try {
+            noteTextarea.focus({ preventScroll: true });
+          } catch (e) {
+            noteTextarea.focus();
+          }
+        }
       }, 0);
     }
 


### PR DESCRIPTION
## Summary
- prevent the page from scrolling when editing a note
- freeze background scrolling while any modal is open

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e3bf8576c833389a6ef69af59625c