### PR TITLE
Fix edit modal scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -917,9 +917,12 @@
       if (note.auteur !== userName && userName !== "Admin") return;
       currentNoteId = note.id;
       noteTextarea.value = note.contenu;
+
+      const currentScrollY = window.scrollY;
       modalNoteOverlay.style.display = "flex";
       body.classList.add("modal-open");
-      setTimeout(() => {
+
+      requestAnimationFrame(() => {
         if (noteTextarea.focus) {
           try {
             noteTextarea.focus({ preventScroll: true });
@@ -927,7 +930,8 @@
             noteTextarea.focus();
           }
         }
-      }, 0);
+        window.scrollTo({ top: currentScrollY });
+      });
     }
 
     // Écoute Firestore, tri par date de création croissante


### PR DESCRIPTION
## Summary
- preserve scroll position when opening the edit modal
- keep overlay centered via flexbox and disable body scrolling when active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e3f861e1c83338e2e1014ec02a15d