### PR TITLE
Move note count below header and center

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,10 +160,11 @@
       }
       #noteCount {
         margin-top: 4px;
+        margin-bottom: 4px;
         font-size: 12px;
         font-style: italic;
         color: #888;
-        text-align: left;
+        text-align: center;
       }
 
     /* Conteneur regroupant recherche et liste pour un alignement commun */
@@ -514,8 +515,8 @@
     <header id="headerTitle">
       Bloc-note collaboratif
     </header>
-    <input type="text" id="recherche" placeholder="Recherche rapide…" />
     <small id="noteCount">0 élément</small>
+    <input type="text" id="recherche" placeholder="Recherche rapide…" />
   </div>
 
   <main id="mainContent">


### PR DESCRIPTION
## Summary
- move the note count element below the header and above the search field
- center the note count text

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5a7e8fc8833386ddc6964962a533