### PR TITLE
Center edit note modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,15 +454,18 @@
       z-index: 1000;
     }
     #modalNoteContent {
-      background-color: #fff;
-      padding: 1.5rem;
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      z-index: 10000;
+      background-color: white;
+      padding: 20px;
       border-radius: 8px;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+      box-shadow: 0 0 20px rgba(0,0,0,0.2);
       max-width: 90%;
       width: 400px;
       text-align: center;
-      position: relative;
-      z-index: 1001;
     }
     .textarea-wrapper {
       position: relative;


### PR DESCRIPTION
## Summary
- fix CSS for note edit modal to remain centered on screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e74c1cbf083338e6e37a1d2010db3