### PR TITLE
Fix presence handling and cleanup note deletion

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,6 +607,7 @@
       <div class="header-texts">
         <div id="headerTitle" class="name">Admin</div>
         <div id="noteCount" class="count">0 élément</div>
+        <div id="userCountHeader" class="count"></div>
       </div>
     </div>
     <input type="text" id="recherche" class="search-bar" placeholder="Recherche rapide..." />
@@ -748,6 +749,7 @@
     // Références des collections
     const notesCollection    = collection(db, "notes");
     const usersCollection    = collection(db, "users");
+    const presenceCollection = collection(db, "presence");
 
     // Éléments DOM
     const textarea         = document.getElementById("noteInput");
@@ -971,7 +973,6 @@
         divNote.className = "note-item";
         divNote.dataset.noteId = note.id;
         viewObserver.observe(divNote);
-        let btnSupprimer = null;
 
         const auteurs = Object.keys(note.vuPar || {});
         const auteurPrincipal = auteurs[0];
@@ -1244,6 +1245,33 @@
       }
     }
 
+    // Gestion de la présence des utilisateurs
+    async function mettreAJourPresence() {
+      try {
+        await setDoc(doc(presenceCollection, userName), {
+          name: userName,
+          timestamp: serverTimestamp()
+        });
+      } catch (err) {
+        console.error("Erreur présence :", err);
+      }
+    }
+
+    async function retirerPresence() {
+      try {
+        await deleteDoc(doc(presenceCollection, userName));
+      } catch (err) {
+        console.error("Erreur retirer présence :", err);
+      }
+    }
+
+    function ecouterPresence() {
+      onSnapshot(presenceCollection, (snapshot) => {
+        if (userCountHeader) {
+          userCountHeader.textContent = `${snapshot.size} en ligne`;
+        }
+      });
+    }
 
     // Écoute en temps réel de la collection 'presence'
 
@@ -1259,8 +1287,8 @@
         updateAvatar();
         modalNameOverlay.style.display = "none";
         mainContent.classList.add("active");
-
-        // Créer présence dès que le nom est chargé
+        ecouterPresence();
+        await mettreAJourPresence();
         return;
       }
 
@@ -1299,6 +1327,8 @@
           body.classList.remove("modal-open");
           document.body.style.overflow = '';
           mainContent.classList.add("active");
+          ecouterPresence();
+          await mettreAJourPresence();
           resolve();
         };
 
@@ -1315,6 +1345,8 @@
           body.classList.remove("modal-open");
           document.body.style.overflow = '';
           mainContent.classList.add("active");
+          ecouterPresence();
+          await mettreAJourPresence();
           resolve();
         };
       });
@@ -1368,6 +1400,7 @@
 
       // Mettre à jour présence Firestore : supprimer ancienne doc, créer nouvelle
       await retirerPresence();
+      await mettreAJourPresence();
 
       modalEditOverlay.style.display = "none";
       body.classList.remove("modal-open");
@@ -1388,6 +1421,7 @@
     };
 
     // À la fermeture ou navigation hors de la page, on retire la présence
+    window.addEventListener("beforeunload", retirerPresence);
 
     // Au chargement de la page, demander le nom avant toute interaction
   window.addEventListener("DOMContentLoaded", async () => {


### PR DESCRIPTION
## Summary
- display connected user count in header
- track user presence in Firestore
- update presence on name change
- cleanup duplicate variable in note rendering

## Testing
- `npm test` *(fails: could not find package.json)*
- `npx htmlhint index.html` *(fails: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e93fbcdf88333813823dfe3c0c34e