### PR TITLE
Réduit le padding pour les boutons emoji et trombone

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     }
 
     textarea {
-      padding-left: 3.2em; /* augmente l'espacement pour laisser de la place à l'emoji */
+      padding-left: 2.8em; /* laisse de l'espace pour l'emoji */
       box-sizing: border-box;
     }
     .header-wrapper {
@@ -161,7 +161,7 @@
     #noteInput {
       flex: 1;
       height: 40px;              /* hauteur réduite */
-      padding: 8px 3em 8px 3.2em; /* espace pour l'emoji et le trombone */
+      padding: 8px 2.5em 8px 2.8em; /* espace pour l'emoji et le trombone */
       font-size: 14px;
       border: 1px solid #ccc;
       border-radius: 6px;


### PR DESCRIPTION
## Summary
- ajuste le padding gauche de la zone de saisie à `2.8em`
- ajuste le padding droit à `2.5em` pour éviter le débordement des boutons emoji et trombone

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fc6fe760c8333bd6980baffa0fc4a