### PR TITLE
Hide spinner after image uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,8 +854,10 @@
       if (!files.length) return;
       floatingPreview.innerHTML = '<div class="spinner"></div><div id="progressText"></div>';
       const progressText = document.getElementById('progressText');
+      const spinner = floatingPreview.querySelector('.spinner');
       floatingPreview.style.display = 'block';
       let idx = 0;
+      let completedUploads = 0;
       for (const file of files) {
         idx++;
         progressText.textContent = `Insertion ${idx} / ${files.length}`;
@@ -873,6 +875,10 @@
           }
         } catch (err) {
           console.error('Erreur upload image :', err);
+        }
+        completedUploads++;
+        if (completedUploads === files.length && spinner) {
+          spinner.style.display = 'none';
         }
       }
       progressText.textContent = `${files.length} prêtes à être envoyées ✅`;


### PR DESCRIPTION
## Summary
- hide the spinner once all images are uploaded in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68503a4d42188333a54369d5d65a0d4e