### PR TITLE
Improve floating preview text centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,12 @@
       padding: 20px;
       display: none;
     }
+    #floatingPreview[style*="display: block"] {
+      display: flex !important;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
     .spinner {
       border: 6px solid #f3f3f3;
       border-top: 6px solid #3498db;


### PR DESCRIPTION
## Summary
- ensure the floating preview text is centered when displayed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685041a47ed88333b3c38aea1722ada1