### PR TITLE
Fix image click editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1153,9 +1153,12 @@
             copyToClipboard(note.texte);
           }, 600);
         });
-        divNote.addEventListener("pointerup", () => {
+        divNote.addEventListener("pointerup", (event) => {
           clearTimeout(longPressTimer);
           if (!longPress) {
+            if (event.target.tagName.toLowerCase() === "img") {
+              return;
+            }
             passerEnModeEdition(divNote, note);
           }
         });


### PR DESCRIPTION
## Summary
- prevent edit modal when clicking on note images

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685048114c108333aa024986d20c6a21