### PR TITLE
Remove scrollToBottom usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,6 @@
         });
       });
       renderNotes();
-      scrollToBottom();
       loader.style.display = "none";
     }, (err) => {
       console.error("Erreur écoute Firestore :", err);
@@ -1294,7 +1293,6 @@
       floatingPreview.innerHTML = "";
       floatingPreview.style.display = "none";
       uploadedImageUrls = [];
-      scrollToBottom();
     });
 
     searchInput.addEventListener("input", () => {


### PR DESCRIPTION
## Summary
- remove `scrollToBottom()` calls after rendering notes and adding a note

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850e2c6fe088333827c163738456460