### PR TITLE
Add lightbox for note images

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,7 +660,55 @@
     border-radius: 50%;
     animation: spin 1s linear infinite;
     z-index: 9999;
-    background-color: transparent;
+  background-color: transparent;
+  }
+
+  .image-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.65);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+  }
+
+  .image-modal-content {
+    background: white;
+    padding: 16px;
+    border-radius: 12px;
+    max-width: 90%;
+    text-align: center;
+  }
+
+  .image-modal-content img {
+    max-width: 100%;
+    border-radius: 8px;
+  }
+
+  .image-modal-buttons {
+    margin-top: 12px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .image-modal-btn {
+    background-color: #28a745;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: bold;
+    transition: background 0.3s ease;
+  }
+
+  .image-modal-btn:hover {
+    background-color: #218838;
   }
 
   @keyframes spin {
@@ -1116,7 +1164,7 @@
           : "";
 
         const imagesHtml = (note.imageUrls && note.imageUrls.length)
-          ? `<div class="note-images">${note.imageUrls.map(u => `<img src="${u}" alt="image">`).join('')}</div>`
+          ? `<div class="note-images">${note.imageUrls.map(u => `<img src="${u}" class="message-image" alt="image">`).join('')}</div>`
           : '';
 
         divNote.innerHTML = `
@@ -1545,6 +1593,27 @@
     // Au chargement de la page, demander le nom avant toute interaction
   window.addEventListener("DOMContentLoaded", async () => {
     await demanderNomUtilisateur();
+
+    const imageModal = document.getElementById("imageModal");
+    const imageModalSrc = document.getElementById("imageModalSrc");
+    const downloadBtn = document.getElementById("downloadBtn");
+    const viewBtn = document.getElementById("viewBtn");
+
+    document.addEventListener("click", function (e) {
+      if (e.target.tagName === "IMG" && e.target.classList.contains("message-image")) {
+        const src = e.target.src;
+        imageModalSrc.src = src;
+        downloadBtn.href = src;
+        viewBtn.href = src;
+        imageModal.style.display = "flex";
+      }
+    });
+
+    imageModal.addEventListener("click", function (e) {
+      if (e.target.id === "imageModal") {
+        imageModal.style.display = "none";
+      }
+    });
   });
 
   document.addEventListener("contextmenu", function (e) {
@@ -1553,5 +1622,14 @@
   </script>
   <div id="floatingPreview"></div>
   <div id="toast"></div>
+  <div id="imageModal" class="image-modal" style="display: none;">
+    <div class="image-modal-content">
+      <img id="imageModalSrc" src="" alt="Aperçu" />
+      <div class="image-modal-buttons">
+        <a id="downloadBtn" class="image-modal-btn" download target="_blank">Télécharger</a>
+        <a id="viewBtn" class="image-modal-btn" target="_blank">Voir</a>
+      </div>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add class `message-image` for rendered note images
- introduce `imageModal` element at end of page
- add styles and JS handlers for floating image lightbox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850f367fab48333b6f033997c131f7d