### PR TITLE
Enable pinch zoom from gesture center

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,6 +688,7 @@
   }
 
 .image-modal-content img {
+    transform-origin: center center;
     max-width: 100%;
     max-height: 60vh;
     border-radius: 8px;
@@ -1623,6 +1624,16 @@
     imageModalSrc.addEventListener("touchstart", function (e) {
       if (e.touches.length === 2) {
         initialDistance = getTouchDistance(e.touches[0], e.touches[1]);
+
+        const center = getTouchCenter(e.touches[0], e.touches[1]);
+        const rect = imageModalSrc.getBoundingClientRect();
+        const offsetX = center.x - rect.left;
+        const offsetY = center.y - rect.top;
+
+        const percentX = (offsetX / rect.width) * 100;
+        const percentY = (offsetY / rect.height) * 100;
+
+        imageModalSrc.style.transformOrigin = `${percentX}% ${percentY}%`;
       }
     }, { passive: false });
 
@@ -1676,6 +1687,13 @@
     const dx = touch2.clientX - touch1.clientX;
     const dy = touch2.clientY - touch1.clientY;
     return Math.sqrt(dx * dx + dy * dy);
+  }
+
+  function getTouchCenter(touch1, touch2) {
+    return {
+      x: (touch1.clientX + touch2.clientX) / 2,
+      y: (touch1.clientY + touch2.clientY) / 2,
+    };
   }
   </script>
   <div id="floatingPreview"></div>


### PR DESCRIPTION
## Summary
- default image transform origin to center
- make pinch zoom start from finger midpoint by updating JS touch handlers

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850ff552af48333bcb9638e11c14b68