### PR TITLE
Add download modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -856,7 +856,7 @@
       cursor: pointer;
     }
 
-    .btn-no {
+  .btn-no {
       background-color: #ccc;
       color: black;
       border: none;
@@ -864,6 +864,27 @@
       border-radius: 20px;
       font-weight: bold;
       cursor: pointer;
+    }
+
+    /* Modal de téléchargement */
+    #confirmDownloadModal {
+      display: none;
+      position: fixed;
+      z-index: 10000;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.5);
+    }
+
+    #confirmDownloadModal .modal-content {
+      background: white;
+      padding: 20px;
+      border-radius: 12px;
+      max-width: 300px;
+      text-align: center;
+      margin: 15% auto;
     }
 
   @keyframes spin {
@@ -1183,6 +1204,35 @@
     let searchTerm    = "";
     let uploadedImageUrls = [];
     let uploadInProgress = false;
+
+    const downloadButton = document.getElementById("downloadBtn");
+    const confirmDownloadModal = document.getElementById("confirmDownloadModal");
+    const confirmDownloadYes = document.getElementById("confirmDownloadYes");
+    const confirmDownloadNo = document.getElementById("confirmDownloadNo");
+
+    downloadButton.addEventListener("click", () => {
+      confirmDownloadModal.style.display = "block";
+    });
+
+    confirmDownloadNo.addEventListener("click", () => {
+      confirmDownloadModal.style.display = "none";
+    });
+
+    confirmDownloadYes.addEventListener("click", () => {
+      let downloadUrl = currentImageUrl;
+      if (downloadUrl.includes("/upload/")) {
+        downloadUrl = downloadUrl.replace("/upload/", "/upload/fl_attachment/");
+      }
+
+      const link = document.createElement("a");
+      link.href = downloadUrl;
+      link.download = "Image_" + currentImageIndex + ".jpg";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      confirmDownloadModal.style.display = "none";
+    });
 
     const viewObserver = new IntersectionObserver((entries) => {
       if (!navigator.onLine) return;
@@ -1929,25 +1979,6 @@
     }
   };
 
-  document.getElementById("downloadBtn").onclick = (e) => {
-    e.preventDefault();
-    document.getElementById("confirmDownloadModal").style.display = "flex";
-  };
-
-  document.getElementById("confirmDownloadNo").onclick = () => {
-    document.getElementById("confirmDownloadModal").style.display = "none";
-  };
-
-  document.getElementById("confirmDownloadYes").onclick = () => {
-    const link = document.createElement("a");
-    link.href = currentImageUrl;
-    link.download = "Image_" + (currentImageIndex + 1) + ".jpg";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    document.getElementById("confirmDownloadModal").style.display = "none";
-  };
-
   function getTouchDistance(touch1, touch2) {
     const dx = touch2.clientX - touch1.clientX;
     const dy = touch2.clientY - touch1.clientY;
@@ -1992,13 +2023,11 @@
       </div>
     </div>
   </div>
-  <div id="confirmDownloadModal" class="modal-overlay" style="display: none;">
-    <div class="modal-confirm-box">
-      <p>Voulez-vous télécharger cette image ?</p>
-      <div class="confirm-btns">
-        <button id="confirmDownloadYes" class="btn-yes">Oui</button>
-        <button id="confirmDownloadNo" class="btn-no">Non</button>
-      </div>
+  <div id="confirmDownloadModal" class="modal">
+    <div class="modal-content">
+      <p>Voulez-vous vraiment télécharger cette image ?</p>
+      <button id="confirmDownloadYes">Oui</button>
+      <button id="confirmDownloadNo">Annuler</button>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- implement confirmation modal for downloading images
- style the new modal
- allow forcing download via Cloudinary `fl_attachment`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6851404c601c8333baa414c94dc889e8