### PR TITLE
Implement chat bubble styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,21 +386,21 @@
       max-width: 80%;
       padding: 10px 16px;
       border-radius: 20px;
-      margin: 6px 0;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      margin: 20px 0;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
       word-break: break-word;
     }
 
     .note-self {
       align-self: flex-end;
-      background-color: #2e7d32;
-      color: white;
+      background-color: #b2fab4;
+      color: black;
       text-align: right;
     }
 
     .note-other {
       align-self: flex-start;
-      background-color: #a5d6a7;
+      background-color: white;
       color: black;
       text-align: left;
     }
@@ -1440,7 +1440,12 @@
 
         const divNote = document.createElement("div");
         const self = note.auteur === userName;
-        divNote.className = `note-item note-bubble ${self ? 'note-self' : 'note-other'}`;
+        divNote.classList.add("note-item", "note-bubble");
+        if (self) {
+          divNote.classList.add("note-self");
+        } else {
+          divNote.classList.add("note-other");
+        }
         divNote.dataset.noteId = note.id;
         viewObserver.observe(divNote);
 


### PR DESCRIPTION
## Summary
- style notes using `.note-bubble`, `.note-self` and `.note-other`
- apply classes when rendering notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685173a7645c8333adf4c08842734b6e