### PR TITLE
Adjust image display in notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -432,18 +432,16 @@
       margin-top: 6px;
     }
     .note-images img {
-      height: auto;
-      width: auto;
-      max-width: 100%;
+      width: 200px;
+      height: 150px;
       margin: 6px auto;
       border-radius: 8px;
       display: block;
       object-fit: contain;
     }
     .note-images.multiple img {
-      height: 200px;
-      width: 300px;
-      max-width: 300px;
+      width: 100px;
+      height: 66px;
       object-fit: cover;
     }
     .note-meta-time {


### PR DESCRIPTION
## Summary
- resize note images based on how many images the note contains
- keep automatic update via `MutationObserver`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68518f7adb088333a2df45fe9c9ef9fa