### PR TITLE
Adjust image size based on count

### DIFF
--- a/index.html
+++ b/index.html
@@ -1428,7 +1428,7 @@
 
     function updateImageContainer(container) {
       const count = container.querySelectorAll('img').length;
-      if (count > 2) {
+      if (count > 1) {
         container.classList.add('multiple');
       } else {
         container.classList.remove('multiple');
@@ -1477,7 +1477,7 @@
           ? `<button class="supprimer" data-id="${note.id}">&times;</button>`
           : "";
 
-        const multipleClass = (note.imageUrls && note.imageUrls.length > 2) ? ' multiple' : '';
+        const multipleClass = (note.imageUrls && note.imageUrls.length > 1) ? ' multiple' : '';
         const imagesHtml = (note.imageUrls && note.imageUrls.length)
           ? `<div class="note-images${multipleClass}">${note.imageUrls.map(u => `<img src="${u}" class="message-image" alt="image">`).join('')}</div>`
           : '';


### PR DESCRIPTION
## Summary
- update logic that toggles `multiple` class when a note has more than one image
- render notes with the `multiple` class when more than one image is attached

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851980a2bc88333a174e3815f7a4e2c