### PR TITLE
Fix spacing for notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1426,16 +1426,10 @@
   }
 
   function updateNoteSpacing() {
-    const notes = Array.from(document.querySelectorAll('.note-item'));
-    for (let i = 1; i < notes.length; i++) {
-      const prev = notes[i - 1];
-      const curr = notes[i];
-      const prevTs = new Date(parseInt(prev.dataset.timestamp || 0));
-      const currTs = new Date(parseInt(curr.dataset.timestamp || 0));
-      const diff = Math.abs((currTs - prevTs) / 1000);
-      curr.style.marginTop = diff <= 30 ? '8px' : '18px';
-    }
-    if (notes[0]) notes[0].style.marginTop = '0px';
+    const notes = document.querySelectorAll('.note-item');
+    notes.forEach((note, index) => {
+      note.style.marginTop = index === 0 ? '0px' : '10px';
+    });
   }
 
 


### PR DESCRIPTION
## Summary
- simplify `updateNoteSpacing` to remove timestamp logic
- always apply 10px top margin between notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851a86155c08333a80c51985bfaca3c