### PR TITLE
Adjust LCD backlight off schedule

### DIFF
--- a/relay_timer_sms.ino
+++ b/relay_timer_sms.ino
@@ -413,7 +413,10 @@ void updateLcdBrightnessByHour() {
   }
 
   DateTime now = rtc.now();
-  bool shouldDim = (now.hour() >= 23) || (now.hour() < 5);
+  int currentMinutes = now.hour() * 60 + now.minute();
+  int dimStartMinutes = 20 * 60;
+  int dimEndMinutes = 5 * 60 + 30;
+  bool shouldDim = (currentMinutes >= dimStartMinutes) || (currentMinutes <= dimEndMinutes);
 
   if (shouldDim == lcdDimmed) {
     return;


### PR DESCRIPTION
### Motivation
- Change the LCD backlight schedule to turn off between 20:00 and 05:30 so the cutoff at 05:30 is handled precisely instead of the previous hour-only window.

### Description
- Update `updateLcdBrightnessByHour()` in `relay_timer_sms.ino` to compute `currentMinutes`, introduce `dimStartMinutes` and `dimEndMinutes`, and determine `shouldDim` using minute-level comparison while preserving the existing `lcd.noBacklight()`/`lcd.backlight()` behavior.

### Testing
- Ran `git diff -- relay_timer_sms.ino` to confirm the source change and ran `command -v arduino-cli` to check tool availability, which reported `arduino-cli` is not installed so no Arduino compilation was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd5e6dc524832aac11aae25d43c01b)